### PR TITLE
fix: Add buildCommand to vercel.json for TypeScript compilation

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "version": 2,
+  "buildCommand": "npm run build",
   "builds": [
     {
       "src": "dist/index.js",


### PR DESCRIPTION
Add buildCommand to vercel.json for TypeScript compilation