### PR TITLE
fix: Point vercel.json to TypeScript source for serverless function

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "src/index.ts",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/src/index.ts"
+    }
+  ]
+}


### PR DESCRIPTION
 Point vercel.json to TypeScript source for serverless function